### PR TITLE
Add ability to specify input as Iterable or Iterator

### DIFF
--- a/src/main/java/com/github/davidmoten/bigsorter/Reader.java
+++ b/src/main/java/com/github/davidmoten/bigsorter/Reader.java
@@ -13,6 +13,8 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import com.github.davidmoten.bigsorter.internal.ReaderFromIterator;
+
 public interface Reader<T> extends Closeable, Iterable<T> {
 
     /**
@@ -171,5 +173,5 @@ public interface Reader<T> extends Closeable, Iterable<T> {
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator(), Spliterator.ORDERED), false)
                 .onClose(() -> Util.close(Reader.this));
     }
-
+    
 }

--- a/src/main/java/com/github/davidmoten/bigsorter/internal/ReaderFromIterator.java
+++ b/src/main/java/com/github/davidmoten/bigsorter/internal/ReaderFromIterator.java
@@ -1,0 +1,34 @@
+package com.github.davidmoten.bigsorter.internal;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import com.github.davidmoten.bigsorter.Reader;
+import com.github.davidmoten.guavamini.Preconditions;
+
+public final class ReaderFromIterator<T> implements Reader<T> {
+
+    private Iterator<? extends T> it;
+
+    public ReaderFromIterator(Iterator<? extends T> it) {
+        Preconditions.checkNotNull(it);
+        this.it = it;
+    }
+
+    @Override
+    public T read() throws IOException {
+        if (it == null || !it.hasNext()) {
+            // help gc
+            it = null;
+            return null;
+        } else {
+            return it.next();
+        }
+    }
+    
+    @Override
+    public void close() throws IOException {
+        // do nothing
+    }
+
+}

--- a/src/test/java/com/github/davidmoten/bigsorter/internal/ReaderFromIteratorTest.java
+++ b/src/test/java/com/github/davidmoten/bigsorter/internal/ReaderFromIteratorTest.java
@@ -1,0 +1,31 @@
+package com.github.davidmoten.bigsorter.internal;
+
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.junit.Test;
+
+public class ReaderFromIteratorTest {
+
+    @Test
+    public void test() throws IOException {
+        ReaderFromIterator<String> r = new ReaderFromIterator<String>(new Iterator<String>() {
+
+            @Override
+            public boolean hasNext() {
+                return false;
+            }
+
+            @Override
+            public String next() {
+                throw new NoSuchElementException();
+            }
+        });
+        assertNull(r.read());
+        assertNull(r.read());
+    }
+    
+}


### PR DESCRIPTION
as per discussion in #27, can now specify input as an Iterable (like a java.util.List) or an Iterator:

```java
List<String> list = Sorter 
    .serializerLinesUtf8() 
    .comparator(Comparator.naturalOrder()) 
    .inputItems(Arrays.asList("bbb", "aaa", "ddd", "ccc")) 
    .outputAsStream() 
    .sort() 
    .collect(Collectors.toList());
System.out.println(list);
```
output:
```
[aaa, bbb, ccc, ddd]
```
