### PR TITLE
add input and output mapping support

### DIFF
--- a/src/main/java/com/github/davidmoten/bigsorter/InputStreamReaderFactory.java
+++ b/src/main/java/com/github/davidmoten/bigsorter/InputStreamReaderFactory.java
@@ -1,0 +1,18 @@
+package com.github.davidmoten.bigsorter;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+
+@FunctionalInterface
+public interface InputStreamReaderFactory<T> {
+
+    Reader<T> createReader(InputStream in);
+
+    default Reader<T> createReader(File file) throws FileNotFoundException {
+        return createReader(new BufferedInputStream(new FileInputStream(file)));
+    }
+    
+}

--- a/src/main/java/com/github/davidmoten/bigsorter/OutputStreamWriterFactory.java
+++ b/src/main/java/com/github/davidmoten/bigsorter/OutputStreamWriterFactory.java
@@ -1,0 +1,18 @@
+package com.github.davidmoten.bigsorter;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+
+@FunctionalInterface
+public interface OutputStreamWriterFactory<T> {
+
+    Writer<T> createWriter(OutputStream out);
+    
+    default Writer<T> createWriter(File file) throws FileNotFoundException {
+        return createWriter(new BufferedOutputStream(new FileOutputStream(file)));
+    }
+    
+}

--- a/src/main/java/com/github/davidmoten/bigsorter/Reader.java
+++ b/src/main/java/com/github/davidmoten/bigsorter/Reader.java
@@ -58,12 +58,12 @@ public interface Reader<T> extends Closeable, Iterable<T> {
         };
     }
 
-    default Reader<T> map(Function<? super T, ? extends T> mapper) {
+    default <S> Reader<S> map(Function<? super T, ? extends S> mapper) {
         Reader<T> r = this;
-        return new Reader<T>() {
+        return new Reader<S>() {
 
             @Override
-            public T read() throws IOException {
+            public S read() throws IOException {
                 T v = r.read();
                 if (v == null) {
                     return null;

--- a/src/main/java/com/github/davidmoten/bigsorter/Serializer.java
+++ b/src/main/java/com/github/davidmoten/bigsorter/Serializer.java
@@ -1,17 +1,9 @@
 package com.github.davidmoten.bigsorter;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.Serializable;
 import java.nio.charset.Charset;
 
@@ -21,19 +13,7 @@ import org.apache.commons.csv.CSVRecord;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.davidmoten.guavamini.Preconditions;
 
-public interface Serializer<T> {
-
-    Reader<T> createReader(InputStream in);
-
-    Writer<T> createWriter(OutputStream out);
-    
-    default Reader<T> createReader(File file) throws FileNotFoundException {
-        return createReader(new BufferedInputStream(new FileInputStream(file)));
-    }
-    
-    default Writer<T> createWriter(File file) throws FileNotFoundException {
-        return createWriter(new BufferedOutputStream(new FileOutputStream(file)));
-    }
+public interface Serializer<T> extends InputStreamReaderFactory<T>, OutputStreamWriterFactory<T> {
 
     static Serializer<String> linesUtf8() {
         return linesUtf8(LineDelimiter.LINE_FEED);

--- a/src/main/java/com/github/davidmoten/bigsorter/Sorter.java
+++ b/src/main/java/com/github/davidmoten/bigsorter/Sorter.java
@@ -508,6 +508,12 @@ public final class Sorter<T> {
         void close() throws IOException;
     }
     
+    ///////////////////////
+    //
+    // Main sort routine  
+    //
+    ///////////////////////
+    
     private File sort() throws IOException {
 
         tempDirectory.mkdirs();

--- a/src/main/java/com/github/davidmoten/bigsorter/Sorter.java
+++ b/src/main/java/com/github/davidmoten/bigsorter/Sorter.java
@@ -401,7 +401,7 @@ public final class Sorter<T> {
             super(b);
         }
         
-        public <S> Builder4<T> map(OutputStreamWriterFactory<? super S> writerFactory, Function<? super T, ? extends S> mapper) {
+        public <S> Builder4<T> outputMapper(OutputStreamWriterFactory<? super S> writerFactory, Function<? super T, ? extends S> mapper) {
             Preconditions.checkArgument(!b.outputWriterFactory.isPresent());
             OutputStreamWriterFactory<T> factory = out -> writerFactory.createWriter(out).map(mapper);
             b.outputWriterFactory  = Optional.of(factory);

--- a/src/main/java/com/github/davidmoten/bigsorter/Sorter.java
+++ b/src/main/java/com/github/davidmoten/bigsorter/Sorter.java
@@ -551,6 +551,9 @@ public final class Sorter<T> {
         }
         log("completed initial split and sort, starting merge, elapsed time="
                 + (System.currentTimeMillis() - time) / 1000.0 + "s");
+
+        // TODO write final merge to final output to avoid possible copying at the end
+        // (and apply outputWriterfactory on the fly if present)
         File result = merge(files);
         if (outputWriterFactory.isPresent()) {
             Util.convert(result, serializer, output, outputWriterFactory.get(), x -> x);

--- a/src/main/java/com/github/davidmoten/bigsorter/Sorter.java
+++ b/src/main/java/com/github/davidmoten/bigsorter/Sorter.java
@@ -58,7 +58,7 @@ public final class Sorter<T> {
     private final File tempDirectory;
     private final boolean unique;
     private final boolean initialSortInParallel;
-    private Optional<OutputStreamWriterFactory<T>> outputWriterFactory;
+    private final Optional<OutputStreamWriterFactory<T>> outputWriterFactory;
     private long count = 0;
 
     Sorter(List<Supplier<? extends Reader<? extends T>>> inputs, Serializer<T> serializer, File output,
@@ -68,6 +68,7 @@ public final class Sorter<T> {
         Preconditions.checkNotNull(serializer, "serializer cannot be null");
         Preconditions.checkNotNull(output, "output cannot be null");
         Preconditions.checkNotNull(comparator, "comparator cannot be null");
+        Preconditions.checkNotNull(outputWriterFactory, "outputWriterFactory cannot be null");
         this.inputs = inputs;
         this.serializer = serializer;
         this.output = output;

--- a/src/main/java/com/github/davidmoten/bigsorter/Util.java
+++ b/src/main/java/com/github/davidmoten/bigsorter/Util.java
@@ -355,9 +355,9 @@ public final class Util {
         }
     }
     
-    public static <S, T> void convert(File in, Serializer<S> inSerializer, File out,  Serializer<T> outSerializer, Function<? super S, ? extends T> mapper) {
-        try (Reader<S> r = inSerializer.createReader(in);
-                Writer<T> w = outSerializer.createWriter(out)) {
+    public static <S, T> void convert(File in, InputStreamReaderFactory<S> readerFactory, File out,
+            OutputStreamWriterFactory<T> writerFactory, Function<? super S, ? extends T> mapper) {
+        try (Reader<S> r = readerFactory.createReader(in); Writer<T> w = writerFactory.createWriter(out)) {
             S s;
             while ((s = r.read()) != null) {
                 w.write(mapper.apply(s));

--- a/src/main/java/com/github/davidmoten/bigsorter/Writer.java
+++ b/src/main/java/com/github/davidmoten/bigsorter/Writer.java
@@ -2,11 +2,33 @@ package com.github.davidmoten.bigsorter;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.function.Function;
 
 public interface Writer<T> extends Closeable {
 
     void write(T value) throws IOException;
     
     void flush() throws IOException;
+    
+    default <S> Writer<S> map(Function<? super S, ? extends T> mapper) {
+        Writer<T> w = this;
+        return new Writer<S>() {
+
+            @Override
+            public void write(S value) throws IOException {
+                w.write(mapper.apply(value));
+            }
+
+            @Override
+            public void flush() throws IOException {
+                w.close();
+            }
+
+            @Override
+            public void close() throws IOException {
+                w.close();
+            }
+        };
+    }
     
 }

--- a/src/test/java/com/github/davidmoten/bigsorter/SO_AnyQuickSortingForAHugeCsvFile.java
+++ b/src/test/java/com/github/davidmoten/bigsorter/SO_AnyQuickSortingForAHugeCsvFile.java
@@ -33,7 +33,7 @@ public class SO_AnyQuickSortingForAHugeCsvFile {
             }
         }
         System.out.println("created input file in " + (System.currentTimeMillis() - t) / 1000.0 + "s");
-        Sorter.serializer(Serializer.csv(CSVFormat.DEFAULT.withRecordSeparator('\n'), //
+        Sorter.serializer(Serializer.csv(CSVFormat.Builder.create().setRecordSeparator('\n').build(), //
                 StandardCharsets.UTF_8)) //
                 .comparator((x, y) -> Integer.compare(Integer.parseInt(x.get(10)),
                         Integer.parseInt(y.get(10)))) //

--- a/src/test/java/com/github/davidmoten/bigsorter/SortIntegersMain.java
+++ b/src/test/java/com/github/davidmoten/bigsorter/SortIntegersMain.java
@@ -35,6 +35,8 @@ public class SortIntegersMain {
                 .output(output) //
                 .map(Serializer.linesUtf8(), x -> Integer.toString(x)) //
                 .loggerStdOut() //
+                .initialSortInParallel() //
+                .maxItemsPerFile(5_000_000) //
                 .sort();
 
         Sorter //
@@ -44,6 +46,8 @@ public class SortIntegersMain {
                 .filter(line -> !line.isEmpty()) //
                 .output(output) //
                 .loggerStdOut() //
+                .initialSortInParallel() //
+                .maxItemsPerFile(5_000_000) //
                 .sort();
 
     }

--- a/src/test/java/com/github/davidmoten/bigsorter/SortIntegersMain.java
+++ b/src/test/java/com/github/davidmoten/bigsorter/SortIntegersMain.java
@@ -33,7 +33,7 @@ public class SortIntegersMain {
                 .naturalOrder() //
                 .input(textInts) //
                 .output(output) //
-                .map(Serializer.linesUtf8(), x -> Integer.toString(x)) //
+                .outputMapper(Serializer.linesUtf8(), x -> Integer.toString(x)) //
                 .loggerStdOut() //
                 .initialSortInParallel() //
                 .maxItemsPerFile(5_000_000) //

--- a/src/test/java/com/github/davidmoten/bigsorter/SortIntegersMain.java
+++ b/src/test/java/com/github/davidmoten/bigsorter/SortIntegersMain.java
@@ -21,25 +21,19 @@ public class SortIntegersMain {
 
         System.out.println("file written");
 
-        long t = System.currentTimeMillis();
-
         Serializer<Integer> intSerializer = Serializer.dataSerializer( //
                 dis -> (Integer) dis.readInt(), //
                 (dos, v) -> dos.writeInt(v));
-
-        // convert input from text integers to 4 byte binary integers
-        File ints = new File("target/numbers-integers");
-        Util.convert(textInts, Serializer.linesUtf8(), ints, intSerializer, line -> Integer.parseInt(line));
-
-        System.out.println("converted in " + (System.currentTimeMillis() - t) / 1000.0 + "s");
 
         File output = new File("target/out");
 
         Sorter //
                 .serializer(intSerializer) //
+                .inputMapper(Serializer.linesUtf8(), line -> Integer.parseInt(line)) //
                 .naturalOrder() //
-                .input(ints) //
+                .input(textInts) //
                 .output(output) //
+                .map(Serializer.linesUtf8(), x -> Integer.toString(x)) //
                 .loggerStdOut() //
                 .sort();
 
@@ -48,7 +42,8 @@ public class SortIntegersMain {
                 .comparator((a, b) -> Integer.compare(Integer.parseInt(a), Integer.parseInt(b))) //
                 .input(textInts) //
                 .filter(line -> !line.isEmpty()) //
-                .output(output).loggerStdOut() //
+                .output(output) //
+                .loggerStdOut() //
                 .sort();
 
     }

--- a/src/test/java/com/github/davidmoten/bigsorter/SorterTest.java
+++ b/src/test/java/com/github/davidmoten/bigsorter/SorterTest.java
@@ -857,7 +857,7 @@ public class SorterTest {
                 .naturalOrder() //
                 .input("456","123", "234") //
                 .output(output) //
-                .map(Serializer.linesUtf8(), x -> Integer.toString(x)) //
+                .outputMapper(Serializer.linesUtf8(), x -> Integer.toString(x)) //
                 .sort();
         List<String> list = Files.readAllLines(output.toPath());
         assertEquals(Arrays.asList("123", "234", "456"), list);

--- a/src/test/java/com/github/davidmoten/bigsorter/SorterTest.java
+++ b/src/test/java/com/github/davidmoten/bigsorter/SorterTest.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -747,7 +748,7 @@ public class SorterTest {
                 emptyReader());
         Sorter<String> sorter = new Sorter<String>(list, Serializer.linesUtf8(),
                 OUTPUT, Comparator.naturalOrder(), 3, 1000, x -> {
-                }, 8192, new File(System.getProperty("java.io.tmpdir")), false, false);
+                }, 8192, new File(System.getProperty("java.io.tmpdir")), false, false, Optional.empty());
         sorter.merge(Lists.newArrayList(new File("target/doesnotexist"), new File("target/doesnotexist2")));
     }
     
@@ -823,25 +824,43 @@ public class SorterTest {
     
     @Test
     public void testSortIntegersFromFileMoreEfficient() throws IOException {
+        File textInts = new File("src/test/resources/numbers.txt");
+        
         Serializer<Integer> intSerializer = Serializer.dataSerializer( //
                 dis -> (Integer) dis.readInt(), //
                 (dos, v) -> dos.writeInt(v));
         
-        // convert input from text integers to 4 byte binary integers
-        File textInts = new File("src/test/resources/numbers.txt");
-        File ints = new File("target/numbers-integers");
-        Util.convert(textInts, Serializer.linesUtf8(), ints, intSerializer, line -> Integer.parseInt(line));
-        
         List<Integer> list = Sorter //
                 .serializer(intSerializer) //
+                .inputMapper(Serializer.linesUtf8(), line -> Integer.parseInt(line)) //
                 .naturalOrder() //
-                .input(ints) //
+                .input(textInts) //
                 .outputAsStream() //
                 .sort() //
                 .collect(Collectors.toList());
+        
         assertEquals(10, list.size());
         assertEquals(66904383, (int) list.get(0));
         assertEquals(1956321588, (int) list.get(list.size() -1 ));
+    }
+    
+    @Test
+    public void testSortIntegersFromFileMoreEfficientOutputIsFileMappedBackToStringLines() throws IOException {
+        Serializer<Integer> intSerializer = Serializer.dataSerializer( //
+                dis -> (Integer) dis.readInt(), //
+                (dos, v) -> dos.writeInt(v));
+        
+        File output = new File("target/output");
+        Sorter //
+                .serializer(intSerializer) //
+                .inputMapper(Serializer.linesUtf8(), line -> Integer.parseInt(line)) //
+                .naturalOrder() //
+                .input("456","123", "234") //
+                .output(output) //
+                .map(Serializer.linesUtf8(), x -> Integer.toString(x)) //
+                .sort();
+        List<String> list = Files.readAllLines(output.toPath());
+        assertEquals(Arrays.asList("123", "234", "456"), list);
     }
     
     static void printOutput() throws IOException {


### PR DESCRIPTION
As mentioned in #44, it can be much more efficient to perform all the sort actions using a faster binary Serializer so I want to make it easier in the builder to 
* start with input in one format
* map the input to another format and do the sorting with that format
* map the output to an output format (possibly the same as the input format)

Using this PR, here's an example with sorting text integers (which for large input is 3-6x faster to do with a binary intermediate format):

Input:
```
456
123
234
```
Code:
```java
Serializer<Integer> intSerializer = Serializer.dataSerializer( //
    dis -> (Integer) dis.readInt(), //
    (dos, v) -> dos.writeInt(v));
        
File output = new File("target/output");
Sorter //
    .serializer(intSerializer) //
    // convert the input for use by the intSerializer
    .inputMapper(Serializer.linesUtf8(), line -> Integer.parseInt(line)) //
    .naturalOrder() //
    .input("456","123", "234") //
    .output(output) //
    // convert the ints back to strings to end up with the original 
    // text format
    .outputMapper(Serializer.linesUtf8(), x -> Integer.toString(x)) //
    .sort();
```